### PR TITLE
prevent double tap zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <title>MReisz.com - Pomodoro Timer</title>
   <meta name="description" content="Pomodoro Timer">
   <meta name="author" content="Michael Reisz">
+  <meta name='viewport' content='user-scalable=0'/>
 
   <link rel="stylesheet" href="./assets/css/pomodoro.min.css">
 </head>


### PR DESCRIPTION
Tapping the increase and decrease buttons too fast will cause unintended zooming.  This should prevent that.